### PR TITLE
Add handover document index

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ BESS reliability depends on evidence that can be inspected before energization, 
 - [Supplier document review tracker](templates/supplier-document-review-tracker.md).
 - [Commissioning evidence matrix](templates/commissioning-evidence-matrix.md).
 - [Punch-list and nonconformance tracker](templates/punch-list-nonconformance-tracker.md).
-- Handover document index.
+- [Handover document index](templates/handover-document-index.md).
 
 ## Repository Topics
 
@@ -31,5 +31,5 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 
 - Add a commissioning evidence matrix.
 - Improve punch-list and nonconformance closeout wording.
-- Add handover document index fields.
+- Improve handover document index fields.
 - Improve acceptance evidence wording in existing templates.

--- a/templates/handover-document-index.md
+++ b/templates/handover-document-index.md
@@ -1,0 +1,32 @@
+# Handover Document Index
+
+Use this index to track the document package needed for BESS commissioning closeout, operations handover, and future audit review.
+
+## Document Index
+
+| Document ID | Document Type | System Area | Owner | Revision | Approval Status | Evidence Link | Closeout Notes |
+|---|---|---|---|---|---|---|---|
+| HND-001 | As-built single-line diagram | Electrical | Engineering lead | Rev C | Approved | Drawing package / document control | Confirm drawing revision matches energized configuration. |
+| HND-002 | Protection settings file | Grid interface | Protection engineer | Rev 2 | Pending approval | Relay upload record | Require final utility acceptance before commercial operation. |
+| HND-003 | Battery rack torque records | Battery racks | Electrical supervisor | Rev A | Approved | Torque record folder | Sample includes tool calibration certificate and rack serial range. |
+| HND-004 | Fire safety interface test record | Fire safety | HSE / commissioning | Rev A | Under review | Functional test report | Confirm reset sequence and alarm visibility in SCADA evidence. |
+| HND-005 | Residual-risk register | Project controls | Commissioning manager | Rev 0 | Draft | Punch-list export | Link any deferred items to approved owner and target close date. |
+|  |  |  |  |  |  |  |  |
+
+## Recommended Document Types
+
+| Type | Examples |
+|---|---|
+| Drawings | Single-line diagrams, layouts, cable schedules, network diagrams, as-built markups. |
+| Procedures | FAT, SAT, commissioning, energization, emergency response, isolation and lockout. |
+| Certificates | Meter calibration, instrument calibration, insulation test certificates, factory certificates. |
+| Test records | Functional tests, point-to-point checks, performance tests, protection tests, BMS/EMS logs. |
+| Registers | Punch list, nonconformance list, residual-risk log, spares list, training attendance. |
+
+## Closeout Rules
+
+- Record the owner for every missing or pending document.
+- Keep revision and approval status separate so a submitted draft is not mistaken for an approved handover record.
+- Link documents to controlled storage when possible instead of using free-text file names only.
+- Identify any residual-risk item that remains open at handover.
+- Check that document IDs match the project document control system before final acceptance.


### PR DESCRIPTION
## Summary
- add a BESS handover document index template
- include document owner, revision, approval, evidence, and closeout fields
- link the template from the README

Closes #7.

## Validation
- git diff --check