### PR TITLE
Add residual risk acceptance template

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ BESS reliability depends on evidence that can be inspected before energization, 
 - [Punch-list and nonconformance tracker](templates/punch-list-nonconformance-tracker.md).
 - [Handover document index](templates/handover-document-index.md).
 - [Acceptance evidence wording guide](templates/acceptance-evidence-wording-guide.md).
+- [Residual-risk acceptance template](templates/residual-risk-acceptance-template.md).
 
 ## Repository Topics
 
@@ -34,3 +35,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Improve punch-list and nonconformance closeout wording.
 - Improve handover document index fields.
 - Add project-specific examples to the acceptance evidence wording guide.
+- Add project-specific residual-risk acceptance examples.

--- a/templates/residual-risk-acceptance-template.md
+++ b/templates/residual-risk-acceptance-template.md
@@ -1,0 +1,26 @@
+# Residual-Risk Acceptance Template
+
+Use this template when a BESS punch-list item or nonconformance is deferred beyond commissioning, energization, or handover with an approved interim control.
+
+## Residual-Risk Register
+
+| ID | Risk Description | Affected System | Interim Control | Owner | Approval | Target Close Date | Status | Closeout Evidence |
+|---|---|---|---|---|---|---|---|---|
+| RR-001 | Auxiliary cabinet label set is incomplete for PCS-02 after final SAT walkdown. | PCS / auxiliary power | Temporary field labels installed; operator informed through handover note. | Electrical supervisor | Commissioning manager accepted on 2026-08-18 | 2026-09-05 | Accepted for deferred closeout | Updated photo log and revised label schedule required before closure. |
+|  |  |  |  |  |  |  |  |  |
+
+## Acceptance Rules
+
+- Use residual-risk acceptance only for items that have an identified owner and interim control.
+- Do not accept deferred work that blocks safety, protection, fire interface, or grid-code compliance unless the responsible authority formally approves the operating restriction.
+- Link the original punch-list or nonconformance ID so reviewers can trace the full decision.
+- State whether the risk affects safety, reliability, performance, documentation, commercial closeout, or operations.
+- Confirm that operations staff know the interim control before handover.
+
+## Approval Questions
+
+- Who owns the risk after handover?
+- What operating condition or system state is allowed while the item remains open?
+- What evidence is required to close the residual-risk item?
+- Does the target close date align with warranty, commercial operation, or grid-owner commitments?
+- Has the residual risk been added to the handover document index?


### PR DESCRIPTION
## Summary
- add a residual-risk acceptance template for deferred BESS punch-list and nonconformance items
- include owner, interim control, approval, target close date, and closeout evidence fields
- link the template from the README

Closes #11.

## Validation
- git diff --check