### PR TITLE
Add BESS closeout review checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ BESS reliability depends on evidence that can be inspected before energization, 
 - [Handover document index](templates/handover-document-index.md).
 - [Acceptance evidence wording guide](templates/acceptance-evidence-wording-guide.md).
 - [Residual-risk acceptance template](templates/residual-risk-acceptance-template.md).
+- [BESS closeout review checklist](templates/closeout-review-checklist.md).
 
 ## Repository Topics
 
@@ -36,3 +37,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Improve handover document index fields.
 - Add project-specific examples to the acceptance evidence wording guide.
 - Add project-specific residual-risk acceptance examples.
+- Add project-specific closeout review checks.

--- a/templates/closeout-review-checklist.md
+++ b/templates/closeout-review-checklist.md
@@ -1,0 +1,21 @@
+# BESS Closeout Review Checklist
+
+Use this checklist before commissioning handover, commercial operation, or final closeout review. It ties together evidence quality, residual risk, punch-list status, and the handover document package.
+
+| Review Area | Pass / Fail Check | Evidence Link | Owner | Status | Notes |
+|---|---|---|---|---|---|
+| Evidence completeness | Every required commissioning item is mapped in the [commissioning evidence matrix](commissioning-evidence-matrix.md). | Evidence matrix / closeout folder | Commissioning manager | Not started | Confirm missing evidence has an owner and due date. |
+| Evidence wording | Acceptance statements follow the [acceptance evidence wording guide](acceptance-evidence-wording-guide.md). | Test records / screenshots / certificates | QA/QC lead | Not started | Avoid vague wording such as "checked" or "received." |
+| Open punch-list items | All punch-list and nonconformance items are closed or explicitly deferred in the [punch-list tracker](punch-list-nonconformance-tracker.md). | Punch-list export | Project controls | Not started | Separate open work from accepted residual risk. |
+| Residual risk | Deferred items are approved in the [residual-risk acceptance template](residual-risk-acceptance-template.md). | Residual-risk register | Owner representative | Not started | Confirm interim controls and target close dates. |
+| Handover package | Required drawings, procedures, certificates, and test records are listed in the [handover document index](handover-document-index.md). | Document index | Document control | Not started | Confirm revision and approval status. |
+| Operations readiness | Operators have received procedures, alarm/trip summary, and known-residual-risk notes. | Training record / handover notes | Operations lead | Not started | Confirm operational restrictions are visible. |
+| Final approval | Closeout package has required owner, EPC, commissioning, and operations sign-offs. | Approval record | Project manager | Not started | Record any conditional acceptance language. |
+
+## Reviewer Prompts
+
+- Can an independent reviewer trace every acceptance statement to a record, screenshot, certificate, or approved deviation?
+- Are open items either closed, owner-assigned, or formally accepted as residual risk?
+- Does the handover package include the latest approved revisions rather than draft or field-markup copies?
+- Are operations staff aware of any interim controls or post-handover obligations?
+- Is the closeout status clear enough for commercial, warranty, and safety review?


### PR DESCRIPTION
## Summary
- add a BESS closeout review checklist
- tie evidence completeness, residual risk, punch-list status, and handover readiness to existing templates
- link the checklist from the README

Closes #13.

## Validation
- git diff --check