### PR TITLE
Add commissioning evidence review examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ BESS reliability depends on evidence that can be inspected before energization, 
 - [Residual-risk acceptance template](templates/residual-risk-acceptance-template.md).
 - [BESS closeout review checklist](templates/closeout-review-checklist.md).
 - [Commissioning hold-point checklist](templates/commissioning-hold-point-checklist.md).
+- [Commissioning evidence review examples](templates/commissioning-evidence-review-examples.md).
 
 ## Repository Topics
 
@@ -40,3 +41,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific residual-risk acceptance examples.
 - Add project-specific closeout review checks.
 - Add project-specific commissioning hold points.
+- Add more accepted/rejected commissioning evidence examples.

--- a/templates/commissioning-evidence-review-examples.md
+++ b/templates/commissioning-evidence-review-examples.md
@@ -1,0 +1,18 @@
+# Commissioning Evidence Review Examples
+
+Use these examples to review whether commissioning evidence is accepted, rejected, or accepted conditionally with a tracked residual risk.
+
+## Review Examples
+
+| Evidence Type | Evidence Submitted | Review Outcome | Reason | Follow-Up |
+|---|---|---|---|---|
+| Screenshot | SCADA screenshot shows all BMS racks online with timestamp, asset name, and no active communication alarms. | Accepted | Evidence proves the stated acceptance condition and is traceable. | Add screenshot ID to the [commissioning evidence matrix](commissioning-evidence-matrix.md). |
+| Screenshot | Cropped image labeled "BMS OK" without timestamp or visible system identifier. | Rejected | Reviewer cannot confirm date, asset, or alarm state. | Resubmit full screenshot using the [acceptance evidence wording guide](acceptance-evidence-wording-guide.md). |
+| Test record | PCS command-following test record includes command source, ramp response, pass/fail result, and signed approver. | Accepted | Test result is complete and tied to the procedure. | Add record ID to the [handover document index](handover-document-index.md). |
+| Certificate | Meter calibration certificate is valid but references a serial number that does not match the handover index. | Conditional | Certificate may be valid, but traceability is unresolved. | Track mismatch in the [punch-list tracker](punch-list-nonconformance-tracker.md). |
+| Deviation | Minor label issue accepted by owner with interim control and target close date. | Conditional | Deferred work is acceptable only with owner, interim control, and closeout evidence. | Add to the [residual-risk acceptance template](residual-risk-acceptance-template.md). |
+| Deviation | Protection settings mismatch marked "will fix later" with no owner or approval. | Rejected | Safety and grid-interface risks cannot be deferred informally. | Block hold point until approved evidence is provided. |
+
+## Reviewer Rule
+
+Accepted evidence should prove the acceptance condition. Conditional evidence should name the residual risk, owner, interim control, and target close date. Rejected evidence should state the missing traceability or acceptance gap clearly enough that the submitter can fix it.


### PR DESCRIPTION
## Summary
- add commissioning evidence review examples for accepted, rejected, and conditional outcomes
- cover screenshots, test records, deviations, and certificates
- link the examples from the README

Closes #17.

## Validation
- git diff --check