### PR TITLE
Add document readiness scoring guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ BESS reliability depends on evidence that can be inspected before energization, 
 - [BESS closeout review checklist](templates/closeout-review-checklist.md).
 - [Commissioning hold-point checklist](templates/commissioning-hold-point-checklist.md).
 - [Commissioning evidence review examples](templates/commissioning-evidence-review-examples.md).
+- [Document readiness scoring guide](templates/document-readiness-scoring-guide.md).
 
 ## Repository Topics
 
@@ -42,3 +43,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific closeout review checks.
 - Add project-specific commissioning hold points.
 - Add more accepted/rejected commissioning evidence examples.
+- Add project-specific document readiness scoring examples.

--- a/templates/document-readiness-scoring-guide.md
+++ b/templates/document-readiness-scoring-guide.md
@@ -1,0 +1,23 @@
+# Document Readiness Scoring Guide
+
+Use this guide to score handover document readiness before closeout review. Pair it with the [handover document index](handover-document-index.md) and [BESS closeout review checklist](closeout-review-checklist.md).
+
+| Score | Readiness Level | Meaning | Closeout Action |
+|---|---|---|---|
+| 0 | Missing | Document is required but not available in the handover package. | Assign owner and target date before closeout can proceed. |
+| 1 | Draft | Document exists but is uncontrolled, incomplete, or not ready for review. | Return to owner with required corrections. |
+| 2 | Submitted | Document is in the package and ready for review but not approved. | Track reviewer, approval status, and comments. |
+| 3 | Approved | Document has required technical approval but may not be accepted by all handover stakeholders. | Add approval record and confirm revision. |
+| 4 | Accepted | Document is approved, indexed, linked, and accepted for handover. | Mark complete in the handover index. |
+
+## Scoring Prompts
+
+- Does the document ID match the project document control system?
+- Does the revision match the installed or tested configuration?
+- Is the approval authority clear?
+- Is the evidence link accessible to the owner, EPC, commissioning team, and operator?
+- Are conditional acceptances captured as residual risk rather than hidden in comments?
+
+## Suggested Use
+
+Add a readiness score column to the handover document index during weekly closeout review. Focus first on safety, protection, grid-interface, and commissioning-test records.


### PR DESCRIPTION
## Summary
- add a handover document readiness scoring guide
- include missing, draft, submitted, approved, and accepted levels
- link the guide from the README

Closes #19.

## Validation
- git diff --check