### PR TITLE
Add BESS closeout owner map

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ BESS reliability depends on evidence that can be inspected before energization, 
 - [Commissioning hold-point checklist](templates/commissioning-hold-point-checklist.md).
 - [Commissioning evidence review examples](templates/commissioning-evidence-review-examples.md).
 - [Document readiness scoring guide](templates/document-readiness-scoring-guide.md).
+- [BESS closeout owner map](templates/closeout-owner-map.md).
 
 ## Repository Topics
 
@@ -44,3 +45,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific commissioning hold points.
 - Add more accepted/rejected commissioning evidence examples.
 - Add project-specific document readiness scoring examples.
+- Add project-specific closeout owner map examples.

--- a/templates/closeout-owner-map.md
+++ b/templates/closeout-owner-map.md
@@ -1,0 +1,20 @@
+# BESS Closeout Owner Map
+
+Use this owner map to clarify who owns evidence, documents, commissioning decisions, operations handover, and residual risk during closeout.
+
+| Role | Owned Artifact | Review Cadence | Escalation Path |
+|---|---|---|---|
+| Commissioning manager | Closeout plan, energization prerequisites, final acceptance package | Weekly until handover | Project director |
+| QA/QC lead | Inspection records, NCR closeout, punch-list status | Twice weekly during closeout | Commissioning manager |
+| Document control | Handover index, supplier manuals, as-built records | Weekly document-health review | Project controls |
+| Electrical lead | Protection settings, test sheets, electrical completion evidence | At each hold point | Engineering manager |
+| Controls engineer | PCS/BMS settings, alarms, event logs, interface test records | At each software/configuration release | Electrical lead |
+| Operations lead | O&M readiness, training records, spares, warranty contacts | Before final walkdown | Asset manager |
+| Project controls | Open-action tracker, schedule risk, closeout metrics | Weekly governance review | Project director |
+
+## Escalation Rules
+
+- Escalate any evidence gap that blocks energization, safety signoff, or contractual acceptance.
+- Assign one accountable owner for each open closeout action before the weekly governance review.
+- Keep residual-risk decisions separate from routine punch-list actions.
+- Record acceptance of deferred work with owner, date, technical rationale, and operations impact.


### PR DESCRIPTION
## Summary
- Add a BESS closeout owner map template for artifact ownership, cadence, and escalation paths.
- Link the template from the README planned contents and contribution entry points.

Closes #21

## Validation
- git diff --check