### PR TITLE
Add BESS closeout timeline template

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 - [Document readiness scoring guide](templates/document-readiness-scoring-guide.md).
 - [BESS closeout owner map](templates/closeout-owner-map.md).
 
+- [BESS Closeout Timeline Template](templates/closeout-timeline-template.md).
+
 ## Repository Topics
 
 ```text
@@ -46,3 +48,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add more accepted/rejected commissioning evidence examples.
 - Add project-specific document readiness scoring examples.
 - Add project-specific closeout owner map examples.
+- Add project-specific examples to the bess closeout timeline template.

--- a/templates/closeout-timeline-template.md
+++ b/templates/closeout-timeline-template.md
@@ -1,0 +1,18 @@
+# BESS Closeout Timeline Template
+
+Use this template for sequencing closeout actions from final inspection through operations handover. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add BESS Closeout Timeline Template for sequencing closeout actions from final inspection through operations handover.
- Link the artifact from the repository index.

Closes #23

## Validation
- git diff --check
