### PR TITLE
Add commissioning shift handover log

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [BESS Closeout Timeline Template](templates/closeout-timeline-template.md).
 
+- [Commissioning Shift Handover Log](templates/commissioning-shift-handover-log.md).
+
 ## Repository Topics
 
 ```text
@@ -49,3 +51,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific document readiness scoring examples.
 - Add project-specific closeout owner map examples.
 - Add project-specific examples to the bess closeout timeline template.
+- Add project-specific examples to the commissioning shift handover log.

--- a/templates/commissioning-shift-handover-log.md
+++ b/templates/commissioning-shift-handover-log.md
@@ -1,0 +1,18 @@
+# Commissioning Shift Handover Log
+
+Use this template for passing open commissioning actions between field teams without losing evidence context. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Commissioning Shift Handover Log for passing open commissioning actions between field teams without losing evidence context.
- Link the artifact from the repository index.

Closes #25

## Validation
- git diff --check
