### PR TITLE
Add warranty evidence checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Commissioning Shift Handover Log](templates/commissioning-shift-handover-log.md).
 
+- [Warranty Evidence Checklist](templates/warranty-evidence-checklist.md).
+
 ## Repository Topics
 
 ```text
@@ -52,3 +54,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific closeout owner map examples.
 - Add project-specific examples to the bess closeout timeline template.
 - Add project-specific examples to the commissioning shift handover log.
+- Add project-specific examples to the warranty evidence checklist.

--- a/templates/warranty-evidence-checklist.md
+++ b/templates/warranty-evidence-checklist.md
@@ -1,0 +1,18 @@
+# Warranty Evidence Checklist
+
+Use this template for separating warranty-critical records from routine handover documents. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Warranty Evidence Checklist for separating warranty-critical records from routine handover documents.
- Link the artifact from the repository index.

Closes #27

## Validation
- git diff --check
