### PR TITLE
Add fire safety interface review

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Warranty Evidence Checklist](templates/warranty-evidence-checklist.md).
 
+- [Fire Safety Interface Review](templates/fire-safety-interface-review.md).
+
 ## Repository Topics
 
 ```text
@@ -55,3 +57,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the bess closeout timeline template.
 - Add project-specific examples to the commissioning shift handover log.
 - Add project-specific examples to the warranty evidence checklist.
+- Add project-specific examples to the fire safety interface review.

--- a/templates/fire-safety-interface-review.md
+++ b/templates/fire-safety-interface-review.md
@@ -1,0 +1,18 @@
+# Fire Safety Interface Review
+
+Use this template for reviewing fire detection, suppression, emergency response, and BESS controls interfaces. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Fire Safety Interface Review for reviewing fire detection, suppression, emergency response, and BESS controls interfaces.
- Link the artifact from the repository index.

Closes #29

## Validation
- git diff --check
