### PR TITLE
Add spare parts readiness checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Fire Safety Interface Review](templates/fire-safety-interface-review.md).
 
+- [Spare Parts Readiness Checklist](templates/spare-parts-readiness-checklist.md).
+
 ## Repository Topics
 
 ```text
@@ -58,3 +60,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the commissioning shift handover log.
 - Add project-specific examples to the warranty evidence checklist.
 - Add project-specific examples to the fire safety interface review.
+- Add project-specific examples to the spare parts readiness checklist.

--- a/templates/spare-parts-readiness-checklist.md
+++ b/templates/spare-parts-readiness-checklist.md
@@ -1,0 +1,18 @@
+# Spare Parts Readiness Checklist
+
+Use this template for confirming spares, consumables, warranty parts, and storage requirements before operations takeover. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Spare Parts Readiness Checklist for confirming spares, consumables, warranty parts, and storage requirements before operations takeover.
- Link the artifact from the repository index.

Closes #31

## Validation
- git diff --check
