### PR TITLE
Add site acceptance risk register

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Spare Parts Readiness Checklist](templates/spare-parts-readiness-checklist.md).
 
+- [Site Acceptance Risk Register](templates/site-acceptance-risk-register.md).
+
 ## Repository Topics
 
 ```text
@@ -61,3 +63,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the warranty evidence checklist.
 - Add project-specific examples to the fire safety interface review.
 - Add project-specific examples to the spare parts readiness checklist.
+- Add project-specific examples to the site acceptance risk register.

--- a/templates/site-acceptance-risk-register.md
+++ b/templates/site-acceptance-risk-register.md
@@ -1,0 +1,18 @@
+# Site Acceptance Risk Register
+
+Use this template for tracking acceptance risks that remain open during SAT, commissioning, and handover. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Site Acceptance Risk Register for tracking acceptance risks that remain open during SAT, commissioning, and handover.
- Link the artifact from the repository index.

Closes #33

## Validation
- git diff --check
