### PR TITLE
Add grid interconnection evidence pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Site Acceptance Risk Register](templates/site-acceptance-risk-register.md).
 
+- [Grid Interconnection Evidence Pack](templates/grid-interconnection-evidence-pack.md).
+
 ## Repository Topics
 
 ```text
@@ -64,3 +66,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the fire safety interface review.
 - Add project-specific examples to the spare parts readiness checklist.
 - Add project-specific examples to the site acceptance risk register.
+- Add project-specific examples to the grid interconnection evidence pack.

--- a/templates/grid-interconnection-evidence-pack.md
+++ b/templates/grid-interconnection-evidence-pack.md
@@ -1,0 +1,18 @@
+# Grid Interconnection Evidence Pack
+
+Use this template for collecting grid-code, protection, metering, and energization evidence for interconnection review. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Grid Interconnection Evidence Pack for collecting grid-code, protection, metering, and energization evidence for interconnection review.
- Link the artifact from the repository index.

Closes #35

## Validation
- git diff --check
