### PR TITLE
Add energization readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Grid Interconnection Evidence Pack](templates/grid-interconnection-evidence-pack.md).
 
+- [Energization Readiness Gate](templates/energization-readiness-gate.md).
+
 ## Repository Topics
 
 ```text
@@ -67,3 +69,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the spare parts readiness checklist.
 - Add project-specific examples to the site acceptance risk register.
 - Add project-specific examples to the grid interconnection evidence pack.
+- Add project-specific examples to the energization readiness gate.

--- a/templates/energization-readiness-gate.md
+++ b/templates/energization-readiness-gate.md
@@ -1,0 +1,18 @@
+# Energization Readiness Gate
+
+Use this template for confirming prerequisites before a BESS project moves from construction completion to energization. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Energization Readiness Gate for confirming prerequisites before a BESS project moves from construction completion to energization.
- Link the artifact from the repository index.

Closes #37

## Validation
- git diff --check
