### PR TITLE
Add O and M training record

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Energization Readiness Gate](templates/energization-readiness-gate.md).
 
+- [O And M Training Record](templates/o-and-m-training-record.md).
+
 ## Repository Topics
 
 ```text
@@ -70,3 +72,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the site acceptance risk register.
 - Add project-specific examples to the grid interconnection evidence pack.
 - Add project-specific examples to the energization readiness gate.
+- Add project-specific examples to the o and m training record.

--- a/templates/o-and-m-training-record.md
+++ b/templates/o-and-m-training-record.md
@@ -1,0 +1,18 @@
+# O And M Training Record
+
+Use this template for recording operations and maintenance training completion before asset handover. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add O And M Training Record for recording operations and maintenance training completion before asset handover.
- Link the artifact from the repository index.

Closes #39

## Validation
- git diff --check
