### PR TITLE
Add defect aging summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [O And M Training Record](templates/o-and-m-training-record.md).
 
+- [Defect Aging Summary](templates/defect-aging-summary.md).
+
 ## Repository Topics
 
 ```text
@@ -73,3 +75,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the grid interconnection evidence pack.
 - Add project-specific examples to the energization readiness gate.
 - Add project-specific examples to the o and m training record.
+- Add project-specific examples to the defect aging summary.

--- a/templates/defect-aging-summary.md
+++ b/templates/defect-aging-summary.md
@@ -1,0 +1,18 @@
+# Defect Aging Summary
+
+Use this template for summarizing old open defects by owner, severity, and closeout path. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Defect Aging Summary for summarizing old open defects by owner, severity, and closeout path.
- Link the artifact from the repository index.

Closes #41

## Validation
- git diff --check
