### PR TITLE
Add cyber asset handover checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Supplier Query Log](templates/supplier-query-log.md).
 
+- [Cyber Asset Handover Checklist](templates/cyber-asset-handover-checklist.md).
+
 ## Repository Topics
 
 ```text
@@ -79,3 +81,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the o and m training record.
 - Add project-specific examples to the defect aging summary.
 - Add project-specific examples to the supplier query log.
+- Add project-specific examples to the cyber asset handover checklist.

--- a/templates/cyber-asset-handover-checklist.md
+++ b/templates/cyber-asset-handover-checklist.md
@@ -1,0 +1,18 @@
+# Cyber Asset Handover Checklist
+
+Use this template for capturing account, network, firmware, and responsibility details for BESS cyber assets. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Cyber Asset Handover Checklist for capturing account, network, firmware, and responsibility details for BESS cyber assets.
- Link the artifact from the repository index.

Closes #45

## Validation
- git diff --check
