### PR TITLE
Add metering acceptance checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Cyber Asset Handover Checklist](templates/cyber-asset-handover-checklist.md).
 
+- [Metering Acceptance Checklist](templates/metering-acceptance-checklist.md).
+
 ## Repository Topics
 
 ```text
@@ -82,3 +84,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the defect aging summary.
 - Add project-specific examples to the supplier query log.
 - Add project-specific examples to the cyber asset handover checklist.
+- Add project-specific examples to the metering acceptance checklist.

--- a/templates/metering-acceptance-checklist.md
+++ b/templates/metering-acceptance-checklist.md
@@ -1,0 +1,18 @@
+# Metering Acceptance Checklist
+
+Use this template for reviewing BESS metering evidence before performance, settlement, or grid-service claims. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Metering Acceptance Checklist for reviewing BESS metering evidence before performance, settlement, or grid-service claims.
- Link the artifact from the repository index.

Closes #47

## Validation
- git diff --check
