### PR TITLE
Add communication interface test log

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Metering Acceptance Checklist](templates/metering-acceptance-checklist.md).
 
+- [Communication Interface Test Log](templates/communication-interface-test-log.md).
+
 ## Repository Topics
 
 ```text
@@ -85,3 +87,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the supplier query log.
 - Add project-specific examples to the cyber asset handover checklist.
 - Add project-specific examples to the metering acceptance checklist.
+- Add project-specific examples to the communication interface test log.

--- a/templates/communication-interface-test-log.md
+++ b/templates/communication-interface-test-log.md
@@ -1,0 +1,18 @@
+# Communication Interface Test Log
+
+Use this template for recording BESS communications tests across PCS, BMS, EMS, SCADA, and metering interfaces. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Communication Interface Test Log for recording BESS communications tests across PCS, BMS, EMS, SCADA, and metering interfaces.
- Link the artifact from the repository index.

Closes #49

## Validation
- git diff --check
