### PR TITLE
Add environmental condition log

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Availability Test Evidence Template](templates/availability-test-evidence-template.md).
 
+- [Environmental Condition Log](templates/environmental-condition-log.md).
+
 ## Repository Topics
 
 ```text
@@ -94,3 +96,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the communication interface test log.
 - Add project-specific examples to the emergency response drill record.
 - Add project-specific examples to the availability test evidence template.
+- Add project-specific examples to the environmental condition log.

--- a/templates/environmental-condition-log.md
+++ b/templates/environmental-condition-log.md
@@ -1,0 +1,18 @@
+# Environmental Condition Log
+
+Use this template for recording environmental conditions that affect commissioning, testing, and acceptance evidence. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Environmental Condition Log for recording environmental conditions that affect commissioning, testing, and acceptance evidence.
- Link the artifact from the repository index.

Closes #55

## Validation
- git diff --check
