### PR TITLE
Add relay settings review checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Environmental Condition Log](templates/environmental-condition-log.md).
 
+- [Relay Settings Review Checklist](templates/relay-settings-review-checklist.md).
+
 ## Repository Topics
 
 ```text
@@ -97,3 +99,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the emergency response drill record.
 - Add project-specific examples to the availability test evidence template.
 - Add project-specific examples to the environmental condition log.
+- Add project-specific examples to the relay settings review checklist.

--- a/templates/relay-settings-review-checklist.md
+++ b/templates/relay-settings-review-checklist.md
@@ -1,0 +1,18 @@
+# Relay Settings Review Checklist
+
+Use this template for checking relay setting evidence and ownership before energization or grid-code acceptance. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Relay Settings Review Checklist for checking relay setting evidence and ownership before energization or grid-code acceptance.
- Link the artifact from the repository index.

Closes #57

## Validation
- git diff --check
