### PR TITLE
Add site walkdown photo log

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Relay Settings Review Checklist](templates/relay-settings-review-checklist.md).
 
+- [Site Walkdown Photo Log](templates/site-walkdown-photo-log.md).
+
 ## Repository Topics
 
 ```text
@@ -100,3 +102,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the availability test evidence template.
 - Add project-specific examples to the environmental condition log.
 - Add project-specific examples to the relay settings review checklist.
+- Add project-specific examples to the site walkdown photo log.

--- a/templates/site-walkdown-photo-log.md
+++ b/templates/site-walkdown-photo-log.md
@@ -1,0 +1,18 @@
+# Site Walkdown Photo Log
+
+Use this template for organizing site walkdown photo evidence by location, system, issue, and closeout owner. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Site Walkdown Photo Log for organizing site walkdown photo evidence by location, system, issue, and closeout owner.
- Link the artifact from the repository index.

Closes #59

## Validation
- git diff --check
