### PR TITLE
Add final acceptance signoff pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ BESS reliability depends on evidence that can be inspected before energization, 
 
 - [Site Walkdown Photo Log](templates/site-walkdown-photo-log.md).
 
+- [Final Acceptance Signoff Pack](templates/final-acceptance-signoff-pack.md).
+
 ## Repository Topics
 
 ```text
@@ -103,3 +105,4 @@ Draft toolkit. Use the templates as starting points and adapt them to project-sp
 - Add project-specific examples to the environmental condition log.
 - Add project-specific examples to the relay settings review checklist.
 - Add project-specific examples to the site walkdown photo log.
+- Add project-specific examples to the final acceptance signoff pack.

--- a/templates/final-acceptance-signoff-pack.md
+++ b/templates/final-acceptance-signoff-pack.md
@@ -1,0 +1,18 @@
+# Final Acceptance Signoff Pack
+
+Use this template for assembling the signatures, evidence links, and residual actions needed for final BESS acceptance. It is intended for BESS project teams that need a concise, reviewable artifact during commissioning, acceptance, or handover.
+
+| Review Area | Prompt | Evidence Or Owner |
+|---|---|---|
+| Scope | Which site, enclosure, subsystem, or work package is covered? | State the boundary and owner before review. |
+| Inputs | Which drawings, test records, logs, or supplier documents are required? | Link document IDs or storage locations. |
+| Readiness | What must be true before this item can be marked ready? | Define pass criteria and required signoff. |
+| Exceptions | Which open items can be deferred without blocking acceptance? | Record rationale, risk, and accountable owner. |
+| Handover | What should operations receive after closeout? | Capture final record, date, and receiving role. |
+
+## Closeout Prompts
+
+- What evidence would a reviewer need if this decision is challenged later?
+- Does the item affect safety, energization, warranty, grid compliance, or only documentation quality?
+- Who owns the next action and when should it be reviewed again?
+- Which unresolved risk should be visible in the final acceptance package?


### PR DESCRIPTION
## Summary
- Add Final Acceptance Signoff Pack for assembling the signatures, evidence links, and residual actions needed for final BESS acceptance.
- Link the artifact from the repository index.

Closes #61

## Validation
- git diff --check
