### PR TITLE
Add BESS template quality gate

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -5,6 +5,17 @@ on:
   pull_request:
     paths:
       - "**.md"
+      - "scripts/**/*.py"
+      - "tests/**/*.py"
+      - ".github/workflows/markdown-maintenance.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**.md"
+      - "scripts/**/*.py"
+      - "tests/**/*.py"
+      - ".github/workflows/markdown-maintenance.yml"
 
 permissions:
   contents: read
@@ -14,7 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Test template validator
+        run: python -m unittest discover -s tests -v
+
+      - name: Validate template structure
+        run: python scripts/validate_templates.py
 
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,4 @@ Contributions should improve practical BESS QA/QC clarity.
 - [ ] The evidence requirement is clear.
 - [ ] No confidential project information is included.
 - [ ] Markdown tables render cleanly.
+- [ ] `python scripts/validate_templates.py` passes.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 [![Markdown maintenance](https://github.com/mohammadrezwankhan/bess-qaqc-toolkit/actions/workflows/markdown-maintenance.yml/badge.svg)](https://github.com/mohammadrezwankhan/bess-qaqc-toolkit/actions/workflows/markdown-maintenance.yml)
 
-Templates and checklists for battery energy storage system QA/QC, FAT/SAT readiness, supplier evidence review, and commissioning handover.
+Templates and checklists for battery energy storage system QA/QC, FAT/SAT
+readiness, supplier evidence review, and commissioning handover.
 
 ## Why This Exists
 
-BESS reliability depends on evidence that can be inspected before energization, commissioning, and handover. This repository collects practical templates that help engineering teams make inspection logic easier to review and reuse.
+BESS reliability depends on evidence that can be inspected before energization,
+commissioning, and handover. This repository collects practical templates that
+help engineering teams make inspection logic easier to review and reuse.
 
 ## Planned Contents
 
@@ -69,12 +72,27 @@ BESS reliability depends on evidence that can be inspected before energization, 
 ## Repository Topics
 
 ```text
-bess battery-energy-storage qaqc commissioning fat sat renewable-energy utility-scale energy-storage
+bess battery-energy-storage qaqc commissioning fat sat
+renewable-energy utility-scale energy-storage
 ```
 
 ## Status
 
-Draft toolkit. Use the templates as starting points and adapt them to project-specific requirements, standards, and contractual obligations.
+Draft toolkit. Use the templates as starting points and adapt them to
+project-specific requirements, standards, and contractual obligations.
+
+## Template Quality Gate
+
+Every template must start with one title and an explanatory paragraph, then
+provide at least one structurally valid Markdown table. The repository workflow
+checks table separators and column counts in addition to testing links.
+
+Run the same checks locally with Python 3.12:
+
+```powershell
+python -m unittest discover -s tests -v
+python scripts/validate_templates.py
+```
 
 ## Contribution Entry Points
 

--- a/scripts/validate_templates.py
+++ b/scripts/validate_templates.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+SEPARATOR_CELL = re.compile(r"^:?-{3,}:?$")
+
+
+def is_table_row(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith("|") and stripped.endswith("|")
+
+
+def table_cells(line: str) -> list[str]:
+    return [cell.strip() for cell in line.strip()[1:-1].split("|")]
+
+
+def table_blocks(lines: list[str]) -> list[tuple[int, list[str]]]:
+    blocks: list[tuple[int, list[str]]] = []
+    index = 0
+    while index < len(lines):
+        if not is_table_row(lines[index]):
+            index += 1
+            continue
+
+        start = index
+        block: list[str] = []
+        while index < len(lines) and is_table_row(lines[index]):
+            block.append(lines[index])
+            index += 1
+        blocks.append((start + 1, block))
+    return blocks
+
+
+def validate_template(path: Path) -> list[tuple[int, str]]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    errors: list[tuple[int, str]] = []
+    nonempty = [(index, line) for index, line in enumerate(lines) if line.strip()]
+
+    if not nonempty:
+        return [(1, "template is empty")]
+
+    first_index, first_line = nonempty[0]
+    if not first_line.startswith("# "):
+        errors.append((first_index + 1, "first content line must be an H1 title"))
+
+    h1_lines = [index for index, line in enumerate(lines) if line.startswith("# ")]
+    if len(h1_lines) != 1:
+        errors.append((1, f"expected exactly one H1 title, found {len(h1_lines)}"))
+
+    if h1_lines:
+        intro_line = next(
+            (
+                (index, lines[index].strip())
+                for index in range(h1_lines[0] + 1, len(lines))
+                if lines[index].strip()
+            ),
+            None,
+        )
+        if intro_line is None:
+            errors.append((h1_lines[0] + 1, "template needs an introductory paragraph"))
+        else:
+            index, content = intro_line
+            if content.startswith(("#", "|", "- ", "* ", "```")):
+                errors.append(
+                    (
+                        index + 1,
+                        "add an introductory paragraph before structured content",
+                    )
+                )
+
+    blocks = table_blocks(lines)
+    if not blocks:
+        errors.append((1, "template must contain at least one Markdown table"))
+
+    for start_line, block in blocks:
+        if len(block) < 3:
+            errors.append(
+                (start_line, "table must include a header, separator, and data row")
+            )
+            continue
+
+        header = table_cells(block[0])
+        separator = table_cells(block[1])
+        if not header or any(not cell for cell in header):
+            errors.append((start_line, "table header cells must not be empty"))
+
+        if len(separator) != len(header) or any(
+            not SEPARATOR_CELL.fullmatch(cell) for cell in separator
+        ):
+            errors.append(
+                (
+                    start_line + 1,
+                    "table separator must match the header width and use at "
+                    "least three dashes",
+                )
+            )
+
+        for offset, row in enumerate(block[2:], start=2):
+            cells = table_cells(row)
+            if len(cells) != len(header):
+                errors.append(
+                    (
+                        start_line + offset,
+                        f"table row has {len(cells)} cells; expected {len(header)}",
+                    )
+                )
+
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate structural conventions in BESS Markdown templates."
+    )
+    parser.add_argument("paths", nargs="*", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    paths = args.paths or sorted(Path("templates").glob("*.md"))
+    if not paths:
+        print("No templates found.", file=sys.stderr)
+        return 1
+
+    error_count = 0
+    for path in paths:
+        for line, message in validate_template(path):
+            print(f"{path}:{line}: {message}", file=sys.stderr)
+            error_count += 1
+
+    if error_count:
+        print(
+            f"Template validation failed with {error_count} error(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Validated {len(paths)} template(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_templates.py
+++ b/tests/test_validate_templates.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.validate_templates import validate_template
+
+
+VALID_TEMPLATE = """# FAT Evidence Log
+
+Use this template to record controlled FAT evidence.
+
+## Evidence
+
+| Item | Owner | Status |
+|---|---|---|
+| Test report | QA/QC | Open |
+"""
+
+
+class TemplateValidatorTests(unittest.TestCase):
+    def validate_text(self, content: str) -> list[tuple[int, str]]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "template.md"
+            path.write_text(content, encoding="utf-8")
+            return validate_template(path)
+
+    def test_accepts_well_formed_template(self):
+        self.assertEqual(self.validate_text(VALID_TEMPLATE), [])
+
+    def test_requires_single_h1(self):
+        content = VALID_TEMPLATE + "\n# Duplicate title\n"
+        errors = self.validate_text(content)
+        self.assertTrue(any("exactly one H1" in message for _, message in errors))
+
+    def test_requires_introductory_paragraph(self):
+        content = VALID_TEMPLATE.replace(
+            "Use this template to record controlled FAT evidence.\n\n", ""
+        )
+        errors = self.validate_text(content)
+        self.assertTrue(
+            any("introductory paragraph" in message for _, message in errors)
+        )
+
+    def test_rejects_invalid_separator(self):
+        content = VALID_TEMPLATE.replace("|---|---|---|", "|--|---|---|")
+        errors = self.validate_text(content)
+        self.assertTrue(any("table separator" in message for _, message in errors))
+
+    def test_rejects_inconsistent_row_width(self):
+        content = VALID_TEMPLATE.replace(
+            "| Test report | QA/QC | Open |", "| Test report | Open |"
+        )
+        errors = self.validate_text(content)
+        self.assertTrue(any("expected 3" in message for _, message in errors))
+
+    def test_requires_at_least_one_table(self):
+        content = """# FAT Evidence Log
+
+Use this template to record controlled FAT evidence.
+
+## Evidence
+
+- Test report
+"""
+        errors = self.validate_text(content)
+        self.assertTrue(
+            any("at least one Markdown table" in message for _, message in errors)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a standard-library validator for all BESS Markdown templates
- enforce one title, an introductory paragraph, at least one table, valid separators, and consistent table widths
- add six unit tests covering valid and malformed templates
- run structural tests, live-template validation, and link checking on pull requests and `main`
- document the quality gate and ignore generated Python cache files

## Why

The toolkit contains 34 operational templates, but its existing workflow only checks links. A malformed table or missing introductory context can make a field template difficult to use while still passing link validation. This gate tests the reusable document structure directly without adding runtime dependencies.

## Validation

- `python -m unittest discover -s tests -v` (6 tests passed)
- `python scripts/validate_templates.py` (34 templates passed)
- `npx --yes markdown-link-check ...` (all repository Markdown links passed)
- `npx --yes markdownlint-cli2 README.md CONTRIBUTING.md`
- `npx --yes prettier --check .github/workflows/markdown-maintenance.yml`
- `git diff --check`