### PR TITLE
Add readiness status policy gate

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -7,6 +7,7 @@ on:
       - "**.md"
       - "scripts/**/*.py"
       - "tests/**/*.py"
+      - "config/*.json"
       - ".github/workflows/markdown-maintenance.yml"
   push:
     branches:
@@ -15,6 +16,7 @@ on:
       - "**.md"
       - "scripts/**/*.py"
       - "tests/**/*.py"
+      - "config/*.json"
       - ".github/workflows/markdown-maintenance.yml"
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ The gate compares status names case-insensitively and exits with code `2` when
 a configured state occurs. Status-definition tables are excluded from the
 roll-up. Running the command without a path summarizes the repository templates.
 
+Use a version-controlled status policy to reject missing values, status typos,
+and project-defined blocking states in one reproducible gate:
+
+```powershell
+python scripts/summarize_status.py project-records `
+  --policy config/readiness-status-policy.example.json `
+  --output project-records\readiness-summary.md
+```
+
+The JSON policy defines `allowed_statuses`, `blocking_statuses`, and the Boolean
+`require_status` rule. Matching is case-insensitive. Policy violations retain
+the source file, line, item, status, and reason in Markdown and JSON output; the
+command exits with code `2` when any violation is found. Copy and adapt the
+[example policy](config/readiness-status-policy.example.json) to the controlled
+vocabulary and release gates for each project.
+
 ## Contribution Entry Points
 
 - Add a commissioning evidence matrix.

--- a/config/readiness-status-policy.example.json
+++ b/config/readiness-status-policy.example.json
@@ -1,0 +1,17 @@
+{
+  "allowed_statuses": [
+    "Not started",
+    "In progress",
+    "Under review",
+    "Pending approval",
+    "Draft",
+    "Approved",
+    "Closed",
+    "Accepted for deferred closeout",
+    "Open",
+    "Blocked",
+    "Failed"
+  ],
+  "blocking_statuses": ["Blocked", "Failed"],
+  "require_status": true
+}

--- a/scripts/summarize_status.py
+++ b/scripts/summarize_status.py
@@ -27,6 +27,22 @@ class StatusRecord:
     column: str
 
 
+@dataclass(frozen=True)
+class StatusPolicy:
+    allowed_statuses: tuple[str, ...]
+    blocking_statuses: tuple[str, ...]
+    require_status: bool
+
+
+@dataclass(frozen=True)
+class PolicyViolation:
+    source: str
+    line: int
+    item: str
+    status: str
+    reason: str
+
+
 def normalize_heading(value: str) -> str:
     return " ".join(value.casefold().split())
 
@@ -119,6 +135,83 @@ def expand_paths(inputs: Sequence[Path]) -> list[Path]:
     return unique
 
 
+def _policy_statuses(document: dict[str, object], key: str) -> tuple[str, ...]:
+    raw_statuses = document.get(key, [])
+    if not isinstance(raw_statuses, list) or any(
+        not isinstance(status, str) or not status.strip() for status in raw_statuses
+    ):
+        raise ValueError(f"policy {key} must be a list of nonempty strings")
+    statuses = tuple(status.strip() for status in raw_statuses)
+    normalized = [status.casefold() for status in statuses]
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"policy {key} contains case-insensitive duplicates")
+    return statuses
+
+
+def load_status_policy(path: Path) -> StatusPolicy:
+    """Load and validate a project-specific readiness status policy."""
+
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError("status policy root must be a JSON object")
+    allowed_keys = {"allowed_statuses", "blocking_statuses", "require_status"}
+    unknown_keys = sorted(set(document) - allowed_keys)
+    if unknown_keys:
+        raise ValueError("status policy has unknown fields: " + ", ".join(unknown_keys))
+
+    require_status = document.get("require_status", False)
+    if not isinstance(require_status, bool):
+        raise ValueError("policy require_status must be true or false")
+    allowed_statuses = _policy_statuses(document, "allowed_statuses")
+    blocking_statuses = _policy_statuses(document, "blocking_statuses")
+    if allowed_statuses:
+        allowed = {status.casefold() for status in allowed_statuses}
+        outside_allowlist = [
+            status for status in blocking_statuses if status.casefold() not in allowed
+        ]
+        if outside_allowlist:
+            raise ValueError(
+                "policy blocking_statuses must also be allowed: "
+                + ", ".join(outside_allowlist)
+            )
+    return StatusPolicy(
+        allowed_statuses=allowed_statuses,
+        blocking_statuses=blocking_statuses,
+        require_status=require_status,
+    )
+
+
+def evaluate_status_policy(
+    records: Sequence[StatusRecord], policy: StatusPolicy
+) -> list[PolicyViolation]:
+    """Return line-level blank, unknown, and blocking status violations."""
+
+    allowed = {status.casefold() for status in policy.allowed_statuses}
+    blocking = {status.casefold() for status in policy.blocking_statuses}
+    violations: list[PolicyViolation] = []
+    for record in records:
+        normalized = record.status.casefold()
+        reason = None
+        if record.status == BLANK_STATUS:
+            if policy.require_status:
+                reason = "status is required"
+        elif allowed and normalized not in allowed:
+            reason = "status is not in allowed_statuses"
+        elif normalized in blocking:
+            reason = "status is blocking"
+        if reason:
+            violations.append(
+                PolicyViolation(
+                    source=record.source,
+                    line=record.line,
+                    item=record.item,
+                    status=record.status,
+                    reason=reason,
+                )
+            )
+    return violations
+
+
 def summarize_records(records: Sequence[StatusRecord]) -> dict[str, object]:
     counts = Counter(record.status for record in records)
     ordered_counts = {
@@ -159,6 +252,32 @@ def render_markdown(summary: dict[str, object]) -> str:
         f"| {_markdown_cell(status)} | {count} |"
         for status, count in status_counts.items()
     )
+    if "status_policy" in summary:
+        policy = summary["status_policy"]
+        violations = summary["policy_violations"]
+        lines.extend(
+            [
+                "",
+                "## Policy Evaluation",
+                "",
+                f"Policy source: {_markdown_cell(policy['source'])}  ",
+                f"Violations: {len(violations)}",
+            ]
+        )
+        if violations:
+            lines.extend(
+                [
+                    "",
+                    "| Source | Line | Item | Status | Reason |",
+                    "| --- | ---: | --- | --- | --- |",
+                ]
+            )
+            lines.extend(
+                "| {source} | {line} | {item} | {status} | {reason} |".format(
+                    **{key: _markdown_cell(value) for key, value in violation.items()}
+                )
+                for violation in violations
+            )
     lines.extend(
         [
             "",
@@ -188,6 +307,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
     parser.add_argument("--output", type=Path)
     parser.add_argument(
+        "--policy",
+        type=Path,
+        help="JSON status policy with allowed, blocking, and completeness rules",
+    )
+    parser.add_argument(
         "--fail-on",
         action="append",
         default=[],
@@ -203,6 +327,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         inputs = args.paths or [Path("templates")]
         paths = expand_paths(inputs)
         records = [record for path in paths for record in extract_status_records(path)]
+        policy = load_status_policy(args.policy) if args.policy else None
     except (OSError, ValueError) as error:
         print(f"Status summary failed: {error}", file=sys.stderr)
         return 1
@@ -212,6 +337,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     summary = summarize_records(records)
+    policy_violations: list[PolicyViolation] = []
+    if policy:
+        policy_violations = evaluate_status_policy(records, policy)
+        summary["status_policy"] = {
+            "source": args.policy.as_posix(),
+            **asdict(policy),
+        }
+        summary["policy_violations"] = [
+            asdict(violation) for violation in policy_violations
+        ]
     if args.format == "json":
         rendered = json.dumps(summary, indent=2) + "\n"
     else:
@@ -233,6 +368,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             "Status summary gate failed on: " + ", ".join(matched),
             file=sys.stderr,
         )
+    for violation in policy_violations:
+        print(
+            f"{violation.source}:{violation.line}: {violation.item}: "
+            f"{violation.reason} ({violation.status})",
+            file=sys.stderr,
+        )
+    if policy_violations:
+        print(
+            f"Status policy gate failed with {len(policy_violations)} violation(s).",
+            file=sys.stderr,
+        )
+    if matched or policy_violations:
         return 2
     return 0
 

--- a/tests/test_summarize_status.py
+++ b/tests/test_summarize_status.py
@@ -9,7 +9,10 @@ from pathlib import Path
 
 from scripts.summarize_status import (
     BLANK_STATUS,
+    StatusPolicy,
+    evaluate_status_policy,
     extract_status_records,
+    load_status_policy,
     main,
     render_markdown,
     summarize_records,
@@ -95,6 +98,87 @@ class StatusSummaryTests(unittest.TestCase):
         self.assertEqual(exit_code, 2)
         self.assertEqual(json.loads(standard_output.getvalue())["row_count"], 4)
         self.assertIn("gate failed on: Blocked", standard_error.getvalue())
+
+    def test_loads_example_status_policy(self):
+        policy = load_status_policy(Path("config/readiness-status-policy.example.json"))
+        self.assertTrue(policy.require_status)
+        self.assertIn("Blocked", policy.blocking_statuses)
+        self.assertIn("Approved", policy.allowed_statuses)
+
+    def test_policy_finds_blank_unknown_and_blocking_rows(self):
+        records = extract_status_records(self.write_document())
+        policy = StatusPolicy(
+            allowed_statuses=("closed", "blocked"),
+            blocking_statuses=("blocked",),
+            require_status=True,
+        )
+        violations = evaluate_status_policy(records, policy)
+        self.assertEqual(
+            [violation.reason for violation in violations],
+            [
+                "status is blocking",
+                "status is required",
+                "status is not in allowed_statuses",
+            ],
+        )
+        self.assertEqual(violations[0].item, "Protection test")
+
+    def test_rejects_invalid_status_policy(self):
+        path = self.write_document(
+            json.dumps(
+                {
+                    "allowed_statuses": ["Closed", "closed"],
+                    "blocking_statuses": [],
+                    "require_status": True,
+                }
+            )
+        )
+        with self.assertRaisesRegex(ValueError, "case-insensitive duplicates"):
+            load_status_policy(path)
+
+        path.write_text(
+            json.dumps(
+                {
+                    "allowed_statuses": ["Closed"],
+                    "blocking_statuses": ["Failed"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "must also be allowed"):
+            load_status_policy(path)
+
+    def test_cli_policy_reports_line_level_violations(self):
+        path = self.write_document()
+        standard_output = io.StringIO()
+        standard_error = io.StringIO()
+        with (
+            contextlib.redirect_stdout(standard_output),
+            contextlib.redirect_stderr(standard_error),
+        ):
+            exit_code = main(
+                [
+                    str(path),
+                    "--format",
+                    "json",
+                    "--policy",
+                    "config/readiness-status-policy.example.json",
+                ]
+            )
+        report = json.loads(standard_output.getvalue())
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(len(report["policy_violations"]), 2)
+        self.assertEqual(
+            {item["reason"] for item in report["policy_violations"]},
+            {"status is blocking", "status is required"},
+        )
+        markdown_report = render_markdown(report)
+        self.assertIn("## Policy Evaluation", markdown_report)
+        self.assertIn(
+            "| Protection test | Blocked | status is blocking |", markdown_report
+        )
+        self.assertIn("Protection test: status is blocking", standard_error.getvalue())
+        self.assertIn("Status policy gate failed with 2", standard_error.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add JSON status policies with allowed, blocking, and required-status rules
- report line-level policy violations in Markdown and JSON roll-ups
- include an adaptable example policy and validate policy-file changes in CI

## Validation
- 16 unit tests passed
- all 34 templates passed structural validation
- live roll-up classified 68 rows and identified exactly four blank statuses
- Ruff, compileall, Markdown lint, 37 links, Prettier, JSON, and whitespace checks passed