### PR TITLE
Add column-specific readiness status rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,18 @@ python scripts/summarize_status.py project-records `
   --output project-records\readiness-summary.md
 ```
 
-The JSON policy defines `allowed_statuses`, `blocking_statuses`, and the Boolean
-`require_status` rule. Matching is case-insensitive. Policy violations retain
-the source file, line, item, status, and reason in Markdown and JSON output; the
-command exits with code `2` when any violation is found. Copy and adapt the
-[example policy](config/readiness-status-policy.example.json) to the controlled
-vocabulary and release gates for each project.
+The JSON policy defines global `allowed_statuses`, `blocking_statuses`, and the
+Boolean `require_status` fallback. Optional `column_rules` can assign a complete
+replacement rule to headings such as `Approval Status` or `Review Status`, so a
+valid state cannot silently appear in the wrong workflow column. Column names
+match case-insensitively after whitespace normalization.
+
+Policy violations retain the source file, line, item, status, column, and reason
+in Markdown and JSON output; the command exits with code `2` when any violation
+is found. Copy and adapt the [example policy](config/readiness-status-policy.example.json)
+to the controlled vocabularies and release gates for each project. A matching
+column rule replaces rather than merges with the global fallback, keeping each
+column's accepted and blocking states explicit.
 
 ## Contribution Entry Points
 

--- a/config/readiness-status-policy.example.json
+++ b/config/readiness-status-policy.example.json
@@ -13,5 +13,24 @@
     "Failed"
   ],
   "blocking_statuses": ["Blocked", "Failed"],
-  "require_status": true
+  "require_status": true,
+  "column_rules": {
+    "Approval Status": {
+      "allowed_statuses": [
+        "Not started",
+        "Draft",
+        "Under review",
+        "Pending approval",
+        "Approved",
+        "Rejected"
+      ],
+      "blocking_statuses": ["Rejected"],
+      "require_status": true
+    },
+    "Review Status": {
+      "allowed_statuses": ["Not started", "Under review", "Approved", "Closed"],
+      "blocking_statuses": [],
+      "require_status": true
+    }
+  }
 }

--- a/scripts/summarize_status.py
+++ b/scripts/summarize_status.py
@@ -28,10 +28,19 @@ class StatusRecord:
 
 
 @dataclass(frozen=True)
+class ColumnStatusPolicy:
+    column: str
+    allowed_statuses: tuple[str, ...]
+    blocking_statuses: tuple[str, ...]
+    require_status: bool
+
+
+@dataclass(frozen=True)
 class StatusPolicy:
     allowed_statuses: tuple[str, ...]
     blocking_statuses: tuple[str, ...]
     require_status: bool
+    column_rules: tuple[ColumnStatusPolicy, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -40,6 +49,7 @@ class PolicyViolation:
     line: int
     item: str
     status: str
+    column: str
     reason: str
 
 
@@ -135,35 +145,34 @@ def expand_paths(inputs: Sequence[Path]) -> list[Path]:
     return unique
 
 
-def _policy_statuses(document: dict[str, object], key: str) -> tuple[str, ...]:
+def _policy_statuses(
+    document: dict[str, object], key: str, context: str
+) -> tuple[str, ...]:
     raw_statuses = document.get(key, [])
     if not isinstance(raw_statuses, list) or any(
         not isinstance(status, str) or not status.strip() for status in raw_statuses
     ):
-        raise ValueError(f"policy {key} must be a list of nonempty strings")
+        raise ValueError(f"{context} {key} must be a list of nonempty strings")
     statuses = tuple(status.strip() for status in raw_statuses)
     normalized = [status.casefold() for status in statuses]
     if len(normalized) != len(set(normalized)):
-        raise ValueError(f"policy {key} contains case-insensitive duplicates")
+        raise ValueError(f"{context} {key} contains case-insensitive duplicates")
     return statuses
 
 
-def load_status_policy(path: Path) -> StatusPolicy:
-    """Load and validate a project-specific readiness status policy."""
-
-    document = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(document, dict):
-        raise ValueError("status policy root must be a JSON object")
+def _parse_status_rule(
+    document: dict[str, object], context: str
+) -> tuple[tuple[str, ...], tuple[str, ...], bool]:
     allowed_keys = {"allowed_statuses", "blocking_statuses", "require_status"}
     unknown_keys = sorted(set(document) - allowed_keys)
     if unknown_keys:
-        raise ValueError("status policy has unknown fields: " + ", ".join(unknown_keys))
+        raise ValueError(f"{context} has unknown fields: " + ", ".join(unknown_keys))
 
     require_status = document.get("require_status", False)
     if not isinstance(require_status, bool):
-        raise ValueError("policy require_status must be true or false")
-    allowed_statuses = _policy_statuses(document, "allowed_statuses")
-    blocking_statuses = _policy_statuses(document, "blocking_statuses")
+        raise ValueError(f"{context} require_status must be true or false")
+    allowed_statuses = _policy_statuses(document, "allowed_statuses", context)
+    blocking_statuses = _policy_statuses(document, "blocking_statuses", context)
     if allowed_statuses:
         allowed = {status.casefold() for status in allowed_statuses}
         outside_allowlist = [
@@ -171,13 +180,81 @@ def load_status_policy(path: Path) -> StatusPolicy:
         ]
         if outside_allowlist:
             raise ValueError(
-                "policy blocking_statuses must also be allowed: "
+                f"{context} blocking_statuses must also be allowed: "
                 + ", ".join(outside_allowlist)
             )
+    return allowed_statuses, blocking_statuses, require_status
+
+
+def load_status_policy(path: Path) -> StatusPolicy:
+    """Load global and column-specific readiness status rules."""
+
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError("status policy root must be a JSON object")
+    allowed_keys = {
+        "allowed_statuses",
+        "blocking_statuses",
+        "require_status",
+        "column_rules",
+    }
+    unknown_keys = sorted(set(document) - allowed_keys)
+    if unknown_keys:
+        raise ValueError("status policy has unknown fields: " + ", ".join(unknown_keys))
+
+    global_document = {
+        key: value for key, value in document.items() if key != "column_rules"
+    }
+    allowed_statuses, blocking_statuses, require_status = _parse_status_rule(
+        global_document,
+        "policy",
+    )
+
+    raw_column_rules = document.get("column_rules", {})
+    if not isinstance(raw_column_rules, dict):
+        raise ValueError("policy column_rules must be a JSON object")
+    column_rules: list[ColumnStatusPolicy] = []
+    normalized_columns: set[str] = set()
+    for raw_column, raw_rule in raw_column_rules.items():
+        if not isinstance(raw_column, str) or not raw_column.strip():
+            raise ValueError("policy column_rules keys must be nonempty strings")
+        column = raw_column.strip()
+        normalized_column = normalize_heading(column)
+        if normalized_column in normalized_columns:
+            raise ValueError(
+                "policy column_rules contains case-insensitive duplicate columns"
+            )
+        normalized_columns.add(normalized_column)
+        if not isinstance(raw_rule, dict):
+            raise ValueError(f"policy column rule {column!r} must be a JSON object")
+        required_rule_fields = {
+            "allowed_statuses",
+            "blocking_statuses",
+            "require_status",
+        }
+        missing_rule_fields = sorted(required_rule_fields - set(raw_rule))
+        if missing_rule_fields:
+            raise ValueError(
+                f"policy column rule {column!r} is missing fields: "
+                + ", ".join(missing_rule_fields)
+            )
+        rule_allowed, rule_blocking, rule_required = _parse_status_rule(
+            raw_rule,
+            f"policy column rule {column!r}",
+        )
+        column_rules.append(
+            ColumnStatusPolicy(
+                column=column,
+                allowed_statuses=rule_allowed,
+                blocking_statuses=rule_blocking,
+                require_status=rule_required,
+            )
+        )
     return StatusPolicy(
         allowed_statuses=allowed_statuses,
         blocking_statuses=blocking_statuses,
         require_status=require_status,
+        column_rules=tuple(column_rules),
     )
 
 
@@ -186,14 +263,18 @@ def evaluate_status_policy(
 ) -> list[PolicyViolation]:
     """Return line-level blank, unknown, and blocking status violations."""
 
-    allowed = {status.casefold() for status in policy.allowed_statuses}
-    blocking = {status.casefold() for status in policy.blocking_statuses}
+    column_rules = {
+        normalize_heading(rule.column): rule for rule in policy.column_rules
+    }
     violations: list[PolicyViolation] = []
     for record in records:
+        selected_rule = column_rules.get(normalize_heading(record.column), policy)
+        allowed = {status.casefold() for status in selected_rule.allowed_statuses}
+        blocking = {status.casefold() for status in selected_rule.blocking_statuses}
         normalized = record.status.casefold()
         reason = None
         if record.status == BLANK_STATUS:
-            if policy.require_status:
+            if selected_rule.require_status:
                 reason = "status is required"
         elif allowed and normalized not in allowed:
             reason = "status is not in allowed_statuses"
@@ -206,6 +287,7 @@ def evaluate_status_policy(
                     line=record.line,
                     item=record.item,
                     status=record.status,
+                    column=record.column,
                     reason=reason,
                 )
             )
@@ -268,12 +350,12 @@ def render_markdown(summary: dict[str, object]) -> str:
             lines.extend(
                 [
                     "",
-                    "| Source | Line | Item | Status | Reason |",
-                    "| --- | ---: | --- | --- | --- |",
+                    "| Source | Line | Item | Status | Column | Reason |",
+                    "| --- | ---: | --- | --- | --- | --- |",
                 ]
             )
             lines.extend(
-                "| {source} | {line} | {item} | {status} | {reason} |".format(
+                "| {source} | {line} | {item} | {status} | {column} | {reason} |".format(
                     **{key: _markdown_cell(value) for key, value in violation.items()}
                 )
                 for violation in violations
@@ -309,7 +391,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--policy",
         type=Path,
-        help="JSON status policy with allowed, blocking, and completeness rules",
+        help="JSON policy with global and column-specific status rules",
     )
     parser.add_argument(
         "--fail-on",
@@ -342,7 +424,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         policy_violations = evaluate_status_policy(records, policy)
         summary["status_policy"] = {
             "source": args.policy.as_posix(),
-            **asdict(policy),
+            "allowed_statuses": policy.allowed_statuses,
+            "blocking_statuses": policy.blocking_statuses,
+            "require_status": policy.require_status,
+            "column_rules": {
+                rule.column: {
+                    "allowed_statuses": rule.allowed_statuses,
+                    "blocking_statuses": rule.blocking_statuses,
+                    "require_status": rule.require_status,
+                }
+                for rule in policy.column_rules
+            },
         }
         summary["policy_violations"] = [
             asdict(violation) for violation in policy_violations
@@ -371,7 +463,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for violation in policy_violations:
         print(
             f"{violation.source}:{violation.line}: {violation.item}: "
-            f"{violation.reason} ({violation.status})",
+            f"{violation.reason} ({violation.status}; column: {violation.column})",
             file=sys.stderr,
         )
     if policy_violations:

--- a/tests/test_summarize_status.py
+++ b/tests/test_summarize_status.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from scripts.summarize_status import (
     BLANK_STATUS,
+    ColumnStatusPolicy,
     StatusPolicy,
     evaluate_status_policy,
     extract_status_records,
@@ -104,6 +105,10 @@ class StatusSummaryTests(unittest.TestCase):
         self.assertTrue(policy.require_status)
         self.assertIn("Blocked", policy.blocking_statuses)
         self.assertIn("Approved", policy.allowed_statuses)
+        self.assertEqual(
+            {rule.column for rule in policy.column_rules},
+            {"Approval Status", "Review Status"},
+        )
 
     def test_policy_finds_blank_unknown_and_blocking_rows(self):
         records = extract_status_records(self.write_document())
@@ -122,6 +127,77 @@ class StatusSummaryTests(unittest.TestCase):
             ],
         )
         self.assertEqual(violations[0].item, "Protection test")
+        self.assertEqual(violations[0].column, "Status")
+
+    def test_column_rule_replaces_global_rule_case_insensitively(self):
+        records = extract_status_records(self.write_document())
+        policy = StatusPolicy(
+            allowed_statuses=(
+                "Closed",
+                "Blocked",
+                "Pending approval",
+            ),
+            blocking_statuses=(),
+            require_status=False,
+            column_rules=(
+                ColumnStatusPolicy(
+                    column=" approval STATUS ",
+                    allowed_statuses=("Approved",),
+                    blocking_statuses=(),
+                    require_status=True,
+                ),
+            ),
+        )
+        violations = evaluate_status_policy(records, policy)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].item, "Operating manual")
+        self.assertEqual(violations[0].column, "Approval Status")
+        self.assertEqual(
+            violations[0].reason,
+            "status is not in allowed_statuses",
+        )
+
+    def test_column_rule_can_define_its_own_blocking_state(self):
+        content = STATUS_DOCUMENT.replace("Pending approval", "Rejected")
+        records = extract_status_records(self.write_document(content))
+        policy = StatusPolicy(
+            allowed_statuses=("Closed", "Blocked", "Rejected"),
+            blocking_statuses=(),
+            require_status=False,
+            column_rules=(
+                ColumnStatusPolicy(
+                    column="Approval Status",
+                    allowed_statuses=("Approved", "Rejected"),
+                    blocking_statuses=("Rejected",),
+                    require_status=True,
+                ),
+            ),
+        )
+        violations = evaluate_status_policy(records, policy)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].status, "Rejected")
+        self.assertEqual(violations[0].reason, "status is blocking")
+
+    def test_column_rule_completeness_overrides_global_optional_status(self):
+        content = STATUS_DOCUMENT.replace("Pending approval", "")
+        records = extract_status_records(self.write_document(content))
+        policy = StatusPolicy(
+            allowed_statuses=(),
+            blocking_statuses=(),
+            require_status=False,
+            column_rules=(
+                ColumnStatusPolicy(
+                    column="Approval Status",
+                    allowed_statuses=("Approved",),
+                    blocking_statuses=(),
+                    require_status=True,
+                ),
+            ),
+        )
+        violations = evaluate_status_policy(records, policy)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].item, "Operating manual")
+        self.assertEqual(violations[0].reason, "status is required")
 
     def test_rejects_invalid_status_policy(self):
         path = self.write_document(
@@ -148,6 +224,69 @@ class StatusSummaryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must also be allowed"):
             load_status_policy(path)
 
+    def test_rejects_invalid_column_rules(self):
+        path = self.write_document(
+            json.dumps(
+                {
+                    "column_rules": {
+                        "Status": {
+                            "allowed_statuses": [],
+                            "blocking_statuses": [],
+                            "require_status": False,
+                        },
+                        " status ": {
+                            "allowed_statuses": [],
+                            "blocking_statuses": [],
+                            "require_status": False,
+                        },
+                    }
+                }
+            )
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate columns"):
+            load_status_policy(path)
+
+        path.write_text(
+            json.dumps(
+                {
+                    "column_rules": {
+                        "Status": {
+                            "allowed_statuses": [],
+                            "blocking_statuses": [],
+                            "require_status": False,
+                            "unexpected": True,
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "unknown fields"):
+            load_status_policy(path)
+
+        path.write_text(
+            json.dumps(
+                {
+                    "column_rules": {
+                        "Status": {
+                            "allowed_statuses": [],
+                            "blocking_statuses": [],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "missing fields: require_status"):
+            load_status_policy(path)
+
+        path.write_text(
+            json.dumps({"column_rules": []}),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "must be a JSON object"):
+            load_status_policy(path)
+
     def test_cli_policy_reports_line_level_violations(self):
         path = self.write_document()
         standard_output = io.StringIO()
@@ -172,10 +311,12 @@ class StatusSummaryTests(unittest.TestCase):
             {item["reason"] for item in report["policy_violations"]},
             {"status is blocking", "status is required"},
         )
+        self.assertIn("Approval Status", report["status_policy"]["column_rules"])
         markdown_report = render_markdown(report)
         self.assertIn("## Policy Evaluation", markdown_report)
         self.assertIn(
-            "| Protection test | Blocked | status is blocking |", markdown_report
+            "| Protection test | Blocked | Status | status is blocking |",
+            markdown_report,
         )
         self.assertIn("Protection test: status is blocking", standard_error.getvalue())
         self.assertIn("Status policy gate failed with 2", standard_error.getvalue())


### PR DESCRIPTION
## Summary

- add case-insensitive, whitespace-normalized `column_rules` to readiness status policies
- let matching Status, Review Status, or Approval Status headings use complete replacement vocabularies and blocking rules
- preserve the top-level policy as the fallback for unmatched columns
- require all rule fields and reject malformed, duplicate, or internally inconsistent column rules
- include the applied column in JSON, Markdown, and stderr violation records
- update the example policy and operator documentation

## Why

A broad global vocabulary can accept a valid status in the wrong workflow column, such as `Approved` in a punch-list status or `Open` in an approval status. The gate needs column semantics without breaking existing policies.

## Impact

Existing JSON policies without `column_rules` keep their current behavior. A matching column rule replaces the fallback completely, making allowed states, blocking states, and completeness explicit for that workflow. Reports now identify the source column that caused each violation.

## Validation

- `python -m unittest discover -s tests -v` (20 tests passed)
- `python scripts/validate_templates.py` (34 templates passed)
- live example-policy integration: 68 rows across 9 files; exactly 4 intentional blank-status violations; exit code 2
- `uvx ruff check scripts tests` and changed-file format check (pass)
- Python 3.12 byte-compilation (pass)
- example policy JSON parsing (pass)
- Markdown lint for changed documentation (0 errors)
- `git diff --check` (pass)