### PR TITLE
Flag future completed calibration measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ was expired, not yet effective, unapproved, or ambiguous on the test date:
 
 ```powershell
 python scripts/audit_calibration_traceability.py project-records `
+  --as-of 2026-07-21 `
   --output project-records\calibration-traceability-audit.md
 ```
 
@@ -260,6 +261,8 @@ duplicate references and IDs, malformed or reversed dates, coverage gaps, and
 overlapping periods are reported with source file and line number. Repeat
 `--completed-status`, `--accepted-calibration-status`, or `--missing-value` to
 replace the corresponding defaults for a project.
+When `--as-of` is supplied, a completed measurement dated after the audit date
+is also reported; planned work may still carry a future date.
 
 Markdown and JSON reports preserve measurement coverage, complete calibration
 history, reverse instrument references, and every finding. The command returns

--- a/scripts/audit_calibration_traceability.py
+++ b/scripts/audit_calibration_traceability.py
@@ -237,6 +237,7 @@ def audit_calibration_traceability(
     measurements: Sequence[MeasurementRecord],
     calibrations: Sequence[CalibrationRecord],
     *,
+    as_of: date | None = None,
     completed_statuses: Sequence[str] = DEFAULT_COMPLETED_STATUSES,
     accepted_calibration_statuses: Sequence[
         str
@@ -360,6 +361,19 @@ def audit_calibration_traceability(
                 )
             else:
                 measurement_dates[measurement] = parsed_test_date
+                if (
+                    as_of is not None
+                    and normalize_heading(measurement.status) in completed
+                    and parsed_test_date > as_of
+                ):
+                    add_issue(
+                        measurement.source,
+                        measurement.line,
+                        measurement.measurement_id,
+                        "future_completed_measurement",
+                        "completed measurement test date is after the audit date "
+                        f"{as_of.isoformat()}",
+                    )
 
     calibration_ids: dict[str, CalibrationRecord] = {}
     calibration_periods: dict[CalibrationRecord, tuple[date, date]] = {}
@@ -535,6 +549,7 @@ def summarize_calibration_traceability(
     calibrations: Sequence[CalibrationRecord],
     issues: Sequence[CalibrationIssue],
     completed_statuses: Sequence[str] = DEFAULT_COMPLETED_STATUSES,
+    as_of: date | None = None,
 ) -> dict[str, object]:
     completed = {normalize_heading(value) for value in completed_statuses}
     references: dict[str, list[str]] = defaultdict(list)
@@ -556,6 +571,7 @@ def summarize_calibration_traceability(
         )
         calibration_items.append(item)
     return {
+        "as_of": None if as_of is None else as_of.isoformat(),
         "source_files": sorted(
             {record.source for record in [*measurements, *calibrations]}
         ),
@@ -593,6 +609,8 @@ def render_markdown(summary: dict[str, object]) -> str:
         f"Instruments: {summary['instrument_count']}  ",
         f"Issues: {summary['issue_count']}",
     ]
+    if summary["as_of"]:
+        lines[5:5] = [f"As of: {summary['as_of']}  ", ""]
     issues = summary["issues"]
     if issues:
         lines.extend(
@@ -689,6 +707,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
     parser.add_argument("--output", type=Path)
     parser.add_argument(
+        "--as-of",
+        metavar="YYYY-MM-DD",
+        help="flag completed measurements dated after this audit date",
+    )
+    parser.add_argument(
         "--completed-status",
         action="append",
         help=(
@@ -712,6 +735,9 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
+        as_of = None if args.as_of is None else _iso_date(args.as_of)
+        if args.as_of is not None and as_of is None:
+            raise ValueError("--as-of must use YYYY-MM-DD")
         completed_statuses = _option_values(
             args.completed_status,
             DEFAULT_COMPLETED_STATUSES,
@@ -742,6 +768,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         issues = audit_calibration_traceability(
             measurements,
             calibrations,
+            as_of=as_of,
             completed_statuses=completed_statuses,
             accepted_calibration_statuses=accepted_statuses,
             missing_values=missing_values,
@@ -755,6 +782,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         calibrations,
         issues,
         completed_statuses,
+        as_of,
     )
     rendered = (
         json.dumps(summary, indent=2) + "\n"

--- a/tests/test_audit_calibration_traceability.py
+++ b/tests/test_audit_calibration_traceability.py
@@ -6,6 +6,7 @@ import json
 import tempfile
 import unittest
 from dataclasses import replace
+from datetime import date
 from pathlib import Path
 
 from scripts.audit_calibration_traceability import (
@@ -58,6 +59,21 @@ class CalibrationTraceabilityTests(unittest.TestCase):
         self.assertEqual(self.measurements[2].status, "Planned")
         self.assertEqual(self.measurements[2].test_date, "2028-02-10")
         self.assertNotIn("no_calibration_at_test_date", self.kinds())
+
+    def test_audit_date_rejects_only_future_completed_measurements(self):
+        measurements = [
+            replace(self.measurements[0], test_date="2026-07-22"),
+            *self.measurements[1:],
+        ]
+        kinds = self.kinds(measurements=measurements, as_of=date(2026, 7, 21))
+
+        self.assertIn("future_completed_measurement", kinds)
+        self.assertEqual(
+            self.kinds(as_of=date(2026, 7, 21)).count(
+                "future_completed_measurement"
+            ),
+            0,
+        )
 
     def test_completed_measurement_requires_covering_calibration(self):
         measurements = [
@@ -207,7 +223,9 @@ class CalibrationTraceabilityTests(unittest.TestCase):
             self.measurements,
             self.calibrations,
             [],
+            as_of=date(2026, 7, 21),
         )
+        self.assertEqual(summary["as_of"], "2026-07-21")
         self.assertEqual(summary["instrument_count"], 3)
         self.assertEqual(
             summary["measurements"][0]["covering_calibration_ids"],
@@ -219,6 +237,7 @@ class CalibrationTraceabilityTests(unittest.TestCase):
         )
         rendered = render_markdown(summary)
         self.assertIn("# Instrument Calibration Traceability Audit", rendered)
+        self.assertIn("As of: 2026-07-21", rendered)
         self.assertIn("## Measurement Coverage", rendered)
         self.assertIn("## Calibration History", rendered)
 
@@ -265,9 +284,18 @@ class CalibrationTraceabilityTests(unittest.TestCase):
     def test_cli_emits_json_for_passing_record(self):
         standard_output = io.StringIO()
         with contextlib.redirect_stdout(standard_output):
-            exit_code = main([str(EXAMPLE_PATH), "--format", "json"])
+            exit_code = main(
+                [
+                    str(EXAMPLE_PATH),
+                    "--as-of",
+                    "2026-07-21",
+                    "--format",
+                    "json",
+                ]
+            )
         self.assertEqual(exit_code, 0)
         report = json.loads(standard_output.getvalue())
+        self.assertEqual(report["as_of"], "2026-07-21")
         self.assertEqual(report["issue_count"], 0)
         self.assertEqual(report["completed_measurement_count"], 2)
 


### PR DESCRIPTION
## Summary
- add an optional --as-of date to the calibration traceability audit
- flag completed measurements dated after the audit date
- preserve future dates for planned measurements and include the date in reports

## Validation
- python -m unittest discover -s tests -q (141 tests)
- dated calibration-audit CLI smoke test