### PR TITLE
Detect overlapping calibration histories

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,9 @@ supported so recalibration does not erase historical traceability.
 require exactly one calibration period per instrument to cover the test date,
 and that period must be `Approved`, `Valid`, or `Accepted`. Unknown instruments,
 duplicate references and IDs, malformed or reversed dates, coverage gaps, and
-overlapping periods are reported with source file and line number. Repeat
+overlapping periods are reported with source file and line number. Overlapping
+certificate periods are flagged even when no completed measurement uses their
+shared date range. Repeat
 `--completed-status`, `--accepted-calibration-status`, or `--missing-value` to
 replace the corresponding defaults for a project.
 When `--as-of` is supplied, a completed measurement dated after the audit date

--- a/scripts/audit_calibration_traceability.py
+++ b/scripts/audit_calibration_traceability.py
@@ -466,6 +466,34 @@ def audit_calibration_traceability(
             calibration
         )
 
+    for instrument_id, history in calibrations_by_instrument.items():
+        valid_history = sorted(
+            (
+                calibration
+                for calibration in history
+                if calibration in calibration_periods
+            ),
+            key=lambda calibration: (
+                calibration_periods[calibration][0],
+                calibration_periods[calibration][1],
+                calibration.calibration_id,
+            ),
+        )
+        for index, calibration in enumerate(valid_history):
+            start, _ = calibration_periods[calibration]
+            for earlier in valid_history[:index]:
+                _, earlier_end = calibration_periods[earlier]
+                if earlier_end < start:
+                    continue
+                add_issue(
+                    calibration.source,
+                    calibration.line,
+                    calibration.calibration_id,
+                    "overlapping_calibration_period",
+                    f"{instrument_id} overlaps {earlier.calibration_id} from "
+                    f"{start.isoformat()} through {earlier_end.isoformat()}",
+                )
+
     for measurement in measurements:
         is_completed = normalize_heading(measurement.status) in completed
         test_date = measurement_dates.get(measurement)

--- a/tests/test_audit_calibration_traceability.py
+++ b/tests/test_audit_calibration_traceability.py
@@ -116,6 +116,19 @@ class CalibrationTraceabilityTests(unittest.TestCase):
             self.kinds(calibrations=[*self.calibrations, overlap]),
         )
 
+    def test_overlapping_periods_are_rejected_without_a_completed_test(self):
+        overlap = replace(
+            self.calibrations[1],
+            calibration_id="CAL-005",
+            valid_from="2027-06-01",
+            valid_through="2028-06-01",
+        )
+
+        kinds = self.kinds(calibrations=[*self.calibrations, overlap])
+
+        self.assertIn("overlapping_calibration_period", kinds)
+        self.assertNotIn("overlapping_calibrations", kinds)
+
     def test_unknown_and_repeated_instrument_references_are_reported(self):
         measurements = [
             replace(


### PR DESCRIPTION
Summary: detect overlapping valid calibration periods before a completed measurement falls within the ambiguous range, with regression coverage and documented behavior. Validation: 142 unit tests and dated calibration-audit CLI smoke test passed.